### PR TITLE
Not in scope "catch" (fixed)

### DIFF
--- a/Email.hs
+++ b/Email.hs
@@ -15,6 +15,7 @@
 module Email where
 
 import Control.Applicative
+import Control.Exception.Base
 import qualified Data.ByteString.Lazy.Char8 as C
 import qualified Data.ByteString.Lazy as B
 {- TMP-NO-MIME


### PR DESCRIPTION
I fixed the compilation of Email.hs ("catch" was not found as it has been moved into Control.Exception.Base). Could you upgrade the package on Hackage too?
